### PR TITLE
Update slack invite links

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ This example app showcases a small portion of what you can accomplish with Stytc
 
 # :question: Need support?
 
-Come join our [Slack community](https://stytch.slack.com/join/shared_invite/zt-2f0fi1ruu-ub~HGouWRmPARM1MTwPESA) to speak directly with a Stytch auth expert!
+Come join our [Slack community](https://stytch.com/docs/resources/support/overview) to speak directly with a Stytch auth expert!


### PR DESCRIPTION
Update Slack Invite links to point to the Support landing page as a single source of truth (Slack invite links expire after 400 uses and need to be updated semi frequently).