### PR TITLE
Upgrade Vanilla JS and Nextjs SDKs for Major Version Bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.5.2",
-        "@stytch/nextjs": "^19.0.0",
-        "@stytch/vanilla-js": "^4.11.2",
+        "@stytch/nextjs": "^21.0.0",
+        "@stytch/vanilla-js": "^5.0.0",
         "@types/node": "20.11.24",
         "@types/react": "18.2.61",
         "@types/react-dom": "18.2.19",
@@ -20,7 +20,7 @@
         "prettier": "^3.2.5",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "stytch": "^10.5.0",
+        "stytch": "^11.4.2",
         "typescript": "5.3.3"
       }
     },
@@ -90,14 +90,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@fortawesome/fontawesome-free": {
@@ -386,30 +378,42 @@
       "license": "MIT"
     },
     "node_modules/@stytch/core": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/@stytch/core/-/core-2.17.0.tgz",
-      "integrity": "sha512-ydFcEuLVrcfY2XbVi+bRchw/RSui4GWJ5gZcuk8Paj9nlRLMWGbwgDAvmvARrbj0CAD5qJyKamkWpFrHSkum1Q==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/@stytch/core/-/core-2.26.0.tgz",
+      "integrity": "sha512-qhnjIvfaMsv9QT2cFBN+4XZ1wo+EaXnSa6jxEs9AV8xhG969QNEdAv56sSgH7TQVuG/vZhHfmyoPhnhvo9lRFQ==",
       "dependencies": {
         "uuid": "8.3.2"
       }
     },
     "node_modules/@stytch/nextjs": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@stytch/nextjs/-/nextjs-19.0.0.tgz",
-      "integrity": "sha512-m9N5bzoiuRqUgRD8zfKBXtZJAvI5gbzXjZV34cEWcDy9l1vCeF6/F5P9yR6Af96GgbqHduGcLmL0fPKP4SWrWQ==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/@stytch/nextjs/-/nextjs-21.1.0.tgz",
+      "integrity": "sha512-4+f6HBj0ajFg4dW0c4oTIb+xhEJjZVyyvaajLVLdXn1jbhLftn5nYqT37irs4nlpT79FW2pohg5ikcY4nS1IQQ==",
       "peerDependencies": {
-        "@stytch/vanilla-js": "^4.9.0",
+        "@stytch/vanilla-js": "^5.0.0",
         "react": ">= 17.0.2",
         "react-dom": ">= 17.0.2"
       }
     },
     "node_modules/@stytch/vanilla-js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@stytch/vanilla-js/-/vanilla-js-4.12.0.tgz",
-      "integrity": "sha512-ygOolktHuU5yDUZ3C09pGucRFUtuNwiURDH8QhdGniVETlpS8Osi4TLIyWS2o/qGmU1dfm5dThosmzZRN/e1cQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@stytch/vanilla-js/-/vanilla-js-5.3.0.tgz",
+      "integrity": "sha512-zBveMT4casOllyhCFM5KWnCXuUH4Zy6VUdBBLxWeCuJ9epVEuhyI6/F/pbBA2QCOfj1z2q5kABfggJBCy6Byqw==",
       "dependencies": {
-        "@stytch/core": "2.17.0",
-        "@types/google-one-tap": "^1.2.0"
+        "@stytch/core": "2.26.0",
+        "@types/google-one-tap": "^1.2.0",
+        "type-fest": "4.15.0"
+      }
+    },
+    "node_modules/@stytch/vanilla-js/node_modules/type-fest": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.15.0.tgz",
+      "integrity": "sha512-tB9lu0pQpX5KJq54g+oHOLumOx+pMep4RaM6liXh2PKmVRFF+/vAtUP0ZaJ0kOySfVNjF6doBWPHhBhISKdlIA==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@swc/helpers": {
@@ -2677,9 +2681,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
-      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.8.0.tgz",
+      "integrity": "sha512-E7CqYpL/t7MMnfGnK/eg416OsFCVUrU/Y3Vwe7QjKhu/BkS1Ms455+2xsqZQVN57/U2MHMBvEb5SrmAZWAIntA==",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -3882,12 +3886,12 @@
       }
     },
     "node_modules/stytch": {
-      "version": "10.17.0",
-      "resolved": "https://registry.npmjs.org/stytch/-/stytch-10.17.0.tgz",
-      "integrity": "sha512-z44xw/KItThXx2+9mn68wmNMTHIvUEu7TAG/Qn/QlFY8CvJ/opWbq6lxdRW8ebc7agvc7TDNvm614+tmZ5Dg/w==",
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/stytch/-/stytch-11.4.2.tgz",
+      "integrity": "sha512-3Q+1JE96XVMAJ6+zRCdze0NsOXEPLrXPS2Pff5ZKw4T/Q8V5a1kHzVDPNymRoPjTl2b8uSWm0CxShxCcVg3Ddw==",
       "dependencies": {
-        "jose": "^4.14.6",
-        "undici": "^5.25.4"
+        "jose": "^5.6.3",
+        "undici": "^6.19.5"
       },
       "engines": {
         "node": ">= 18.0.0"
@@ -4097,14 +4101,11 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.4.tgz",
-      "integrity": "sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.8.tgz",
+      "integrity": "sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.5.2",
-    "@stytch/nextjs": "^19.0.0",
-    "@stytch/vanilla-js": "^4.11.2",
+    "@stytch/nextjs": "^21.0.0",
+    "@stytch/vanilla-js": "^5.0.0",
     "@types/node": "20.11.24",
     "@types/react": "18.2.61",
     "@types/react-dom": "18.2.19",
@@ -21,7 +21,7 @@
     "prettier": "^3.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "stytch": "^10.5.0",
+    "stytch": "^11.4.2",
     "typescript": "5.3.3"
   }
 }


### PR DESCRIPTION
# Description
Upgrading `vanilla-js` and `nextjs` SDKs to account for recent version bump that introduced the following:
> Updated API routes to use api.stytch.com for live and test.stytch.com for test, replacing web.stytch.com. If you use Content Security Policy (CSP) headers, ensure the URL is updated. This was done to reduce the number of network calls and simplify internal routing, resulting in faster API response times—improving request speeds by up to 40 milliseconds roundtrip.