### PR TITLE
Add Role Copy for Settings & SSO

### DIFF
--- a/lib/adminPortalConfig.ts
+++ b/lib/adminPortalConfig.ts
@@ -1,0 +1,32 @@
+import { AdminPortalB2BProducts } from '@stytch/nextjs/b2b/adminPortal'
+
+type Role = {
+  role_id: string;
+  description: string;
+}
+
+export const config = {
+  allowedAuthMethods: [AdminPortalB2BProducts.emailMagicLinks, AdminPortalB2BProducts.sso],
+  getRoleDescription: (role: Role) => {
+    if (role.role_id == 'stytch_admin') {
+      return 'Able to manage settings and members'
+    } else if (role.role_id == 'stytch_member') {
+      return 'Able to view settings and members, but cannot edit'
+    } else {
+      return role.description;
+    }
+  },
+  getRoleDisplayName: (role: Role) => {
+    if (role.role_id == 'stytch_admin') {
+      return 'Admin'
+    } else if (role.role_id == 'stytch_member') {
+      return 'Member'
+    } else {
+      return role.role_id
+    }
+  }
+}
+
+export const styles = {
+  fontFamily: 'Courier New',
+}

--- a/src/components/Members.tsx
+++ b/src/components/Members.tsx
@@ -1,35 +1,11 @@
 import { AdminPortalMemberManagement } from '@stytch/nextjs/b2b/adminPortal'
+import { config, styles } from '@/lib/adminPortalConfig';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 
 const Members = () => {
 
-  const styles = {
-    fontFamily: "Courier New",
-  };
-
-  const config = {
-    getRoleDescription: (role: any) => {
-        if (role.role_id == 'stytch_admin') {
-            return 'Able to manage settings and members'
-        } else if (role.role_id == 'stytch_member') {
-            return 'Able to view settings and members, but cannot edit'
-        } else {
-            return 'Your custom role description here!'
-        }
-    },
-    getRoleDisplayName: (role: any) => {
-        if (role.role_id == 'stytch_admin') {
-            return 'Admin'
-        } else if (role.role_id == 'stytch_member') {
-            return 'Member'
-        } else {
-            return role.role_id
-        }
-    }
-  };
-
   return (
-      <AdminPortalMemberManagement config={config} styles={styles} />
+    <AdminPortalMemberManagement config={config} styles={styles} />
   );
 };
 

--- a/src/components/SSO.tsx
+++ b/src/components/SSO.tsx
@@ -6,8 +6,29 @@ const SSO = () => {
     fontFamily: "Courier New",
   };
 
+  const config = {
+    getRoleDescription: (role: any) => {
+      if (role.role_id == 'stytch_admin') {
+          return 'Able to manage settings and members'
+      } else if (role.role_id == 'stytch_member') {
+          return 'Able to view settings and members, but cannot edit'
+      } else {
+          return 'Your custom role description here!'
+      }
+    },
+    getRoleDisplayName: (role: any) => {
+        if (role.role_id == 'stytch_admin') {
+            return 'Admin'
+        } else if (role.role_id == 'stytch_member') {
+            return 'Member'
+        } else {
+            return role.role_id
+        }
+    }
+  }
+
   return (
-      <AdminPortalSSO styles={styles} />
+      <AdminPortalSSO config={config} styles={styles} />
   );
 };
 

--- a/src/components/SSO.tsx
+++ b/src/components/SSO.tsx
@@ -1,34 +1,11 @@
 import { AdminPortalSSO } from '@stytch/nextjs/b2b/adminPortal'
 import '@fortawesome/fontawesome-free/css/all.min.css';
+import { config, styles } from '@/lib/adminPortalConfig';
 
 const SSO = () => {
-  const styles = {
-    fontFamily: "Courier New",
-  };
-
-  const config = {
-    getRoleDescription: (role: any) => {
-      if (role.role_id == 'stytch_admin') {
-          return 'Able to manage settings and members'
-      } else if (role.role_id == 'stytch_member') {
-          return 'Able to view settings and members, but cannot edit'
-      } else {
-          return 'Your custom role description here!'
-      }
-    },
-    getRoleDisplayName: (role: any) => {
-        if (role.role_id == 'stytch_admin') {
-            return 'Admin'
-        } else if (role.role_id == 'stytch_member') {
-            return 'Member'
-        } else {
-            return role.role_id
-        }
-    }
-  }
 
   return (
-      <AdminPortalSSO config={config} styles={styles} />
+    <AdminPortalSSO config={config} styles={styles} />
   );
 };
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -5,7 +5,27 @@ const Settings = () => {
   const styles = {
     fontFamily: "Courier New",
   };
-  const config = {allowedAuthMethods: [AdminPortalB2BProducts.emailMagicLinks, AdminPortalB2BProducts.sso]};
+  const config = {
+    allowedAuthMethods: [AdminPortalB2BProducts.emailMagicLinks, AdminPortalB2BProducts.sso],
+    getRoleDescription: (role: any) => {
+      if (role.role_id == 'stytch_admin') {
+          return 'Able to manage settings and members'
+      } else if (role.role_id == 'stytch_member') {
+          return 'Able to view settings and members, but cannot edit'
+      } else {
+          return 'Your custom role description here!'
+      }
+    },
+    getRoleDisplayName: (role: any) => {
+        if (role.role_id == 'stytch_admin') {
+            return 'Admin'
+        } else if (role.role_id == 'stytch_member') {
+            return 'Member'
+        } else {
+            return role.role_id
+        }
+    }
+  };
 
   return (
       <AdminPortalOrgSettings config={config} styles={styles} />

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,34 +1,11 @@
 import { AdminPortalOrgSettings, AdminPortalB2BProducts } from '@stytch/nextjs/b2b/adminPortal'
 import '@fortawesome/fontawesome-free/css/all.min.css';
+import { config, styles } from '@/lib/adminPortalConfig';
 
 const Settings = () => {
-  const styles = {
-    fontFamily: "Courier New",
-  };
-  const config = {
-    allowedAuthMethods: [AdminPortalB2BProducts.emailMagicLinks, AdminPortalB2BProducts.sso],
-    getRoleDescription: (role: any) => {
-      if (role.role_id == 'stytch_admin') {
-          return 'Able to manage settings and members'
-      } else if (role.role_id == 'stytch_member') {
-          return 'Able to view settings and members, but cannot edit'
-      } else {
-          return 'Your custom role description here!'
-      }
-    },
-    getRoleDisplayName: (role: any) => {
-        if (role.role_id == 'stytch_admin') {
-            return 'Admin'
-        } else if (role.role_id == 'stytch_member') {
-            return 'Member'
-        } else {
-            return role.role_id
-        }
-    }
-  };
 
   return (
-      <AdminPortalOrgSettings config={config} styles={styles} />
+    <AdminPortalOrgSettings config={config} styles={styles} />
   );
 };
 


### PR DESCRIPTION
# Description
The Authentication & Access Settings and SSO components both reference roles -- so adding the config option to override the `role_id` and description with more end user friendly text

<img width="831" alt="Screenshot 2024-09-12 at 11 53 56 AM" src="https://github.com/user-attachments/assets/723ac54f-42a8-4f8c-928a-20ab98f739bb">
