### PR TITLE
Handle Displaying TOTP Recovery Codes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.5.2",
         "@next/font": "^14.2.15",
-        "@stytch/nextjs": "^21.2.0",
-        "@stytch/vanilla-js": "^5.15.0",
+        "@stytch/nextjs": "^21.5.0",
+        "@stytch/vanilla-js": "^5.23.4",
         "@types/node": "20.11.24",
         "@types/react": "18.2.61",
         "@types/react-dom": "18.2.19",
@@ -21,7 +21,7 @@
         "prettier": "^3.2.5",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "stytch": "^12.4.0",
+        "stytch": "^12.19.0",
         "typescript": "5.3.3"
       }
     },
@@ -387,17 +387,17 @@
       "license": "MIT"
     },
     "node_modules/@stytch/core": {
-      "version": "2.40.0",
-      "resolved": "https://registry.npmjs.org/@stytch/core/-/core-2.40.0.tgz",
-      "integrity": "sha512-Qp8urkw2ErrHsueNxrPTyKsbCmB7HgcOUpGLukk8fFWbqHLYfEd77SRwkbcUNi2gY4tkza0UZdFgi1jYRb6IfA==",
+      "version": "2.49.2",
+      "resolved": "https://registry.npmjs.org/@stytch/core/-/core-2.49.2.tgz",
+      "integrity": "sha512-sKHpCqXYdMrTsHEOHancqI2upH3L0l64H3RHInoBoX0eworVdFQ94kueHSjzK+wK/bG2Hnik0rV5Xe/trq6igw==",
       "dependencies": {
         "uuid": "8.3.2"
       }
     },
     "node_modules/@stytch/nextjs": {
-      "version": "21.2.0",
-      "resolved": "https://registry.npmjs.org/@stytch/nextjs/-/nextjs-21.2.0.tgz",
-      "integrity": "sha512-SzmRzpQlQHg/5iw4y+s2fOQlWOFIdFxfnkNp1JGp428mfOZXp9Ckgxo0zJ4NHOoRxZO3h8KytHlmzN4ln12j7w==",
+      "version": "21.5.0",
+      "resolved": "https://registry.npmjs.org/@stytch/nextjs/-/nextjs-21.5.0.tgz",
+      "integrity": "sha512-Mpn3iZnv9DCVsDmQdrYkbz+8rhII8CkiXwv5xugXJFssDkA6W3Nbh7ImAUwGpBBYaZzLSafY5AbsD+UnJZ9LzQ==",
       "peerDependencies": {
         "@stytch/vanilla-js": "^5.0.0",
         "react": ">= 17.0.2",
@@ -405,11 +405,11 @@
       }
     },
     "node_modules/@stytch/vanilla-js": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@stytch/vanilla-js/-/vanilla-js-5.15.0.tgz",
-      "integrity": "sha512-6hsIyu65aHgBwsWJvEUWtZQDy4aU9drjXGugPkxb0pupwd/ITeRpuO2YG29JEGx3DQ8ePFptnqWVMg5j5/3Elg==",
+      "version": "5.23.4",
+      "resolved": "https://registry.npmjs.org/@stytch/vanilla-js/-/vanilla-js-5.23.4.tgz",
+      "integrity": "sha512-u5UH7wEPyD2pkyqLqO8YgJDPC1H5OxZrJmNQ6ZRnyFAZAfhEMvE/lFyDEm6kaPyWWPYBCuZUfCdFS2/9dfn7+A==",
       "dependencies": {
-        "@stytch/core": "2.40.0",
+        "@stytch/core": "2.49.2",
         "@types/google-one-tap": "^1.2.0",
         "type-fest": "4.15.0"
       }
@@ -3895,9 +3895,9 @@
       }
     },
     "node_modules/stytch": {
-      "version": "12.4.0",
-      "resolved": "https://registry.npmjs.org/stytch/-/stytch-12.4.0.tgz",
-      "integrity": "sha512-jyYIfirVnhy3gAtGLEIK5c5tSp5bhi9tUE0JRzItJlwISBW/StMMOvP0hhPUb831EGjV2l1S4YRPg/NqJ+eYNg==",
+      "version": "12.19.0",
+      "resolved": "https://registry.npmjs.org/stytch/-/stytch-12.19.0.tgz",
+      "integrity": "sha512-b7yUFJ+ImXDPgBpECr20F83eQXT6FsVv0N9ENrXwoEpLZk9jieJ8pUnd+Xa+ilMtcfEovQQklrxoGfj0A+761Q==",
       "dependencies": {
         "jose": "^5.6.3",
         "undici": "^6.19.5"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.5.2",
     "@next/font": "^14.2.15",
-    "@stytch/nextjs": "^21.2.0",
-    "@stytch/vanilla-js": "^5.15.0",
+    "@stytch/nextjs": "^21.5.0",
+    "@stytch/vanilla-js": "^5.23.4",
     "@types/node": "20.11.24",
     "@types/react": "18.2.61",
     "@types/react-dom": "18.2.19",
@@ -22,7 +22,7 @@
     "prettier": "^3.2.5",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "stytch": "^12.4.0",
+    "stytch": "^12.19.0",
     "typescript": "5.3.3"
   }
 }

--- a/src/app/authenticate/page.tsx
+++ b/src/app/authenticate/page.tsx
@@ -1,20 +1,26 @@
 'use client';
 
 import Login from '@/src/components/Login';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
-import { useStytchMember } from '@stytch/nextjs/b2b';
+import { useStytchMemberSession } from '@stytch/nextjs/b2b';
 
 export default function AuthenticatePage() {
-  const { member, isInitialized } = useStytchMember();
+  const { session, isInitialized } = useStytchMemberSession();
   const router = useRouter();
 
-  // If the Stytch SDK no longer has a User then redirect to login; for example after logging out.
+  const alreadyLoggedInRef = useRef<boolean>();
+  const hasSession = !!session;
   useEffect(() => {
-    if (isInitialized && member) {
-      router.replace('/dashboard');
+    if (isInitialized && alreadyLoggedInRef.current === undefined) {
+      alreadyLoggedInRef.current = hasSession;
+
+      if (hasSession) {
+        // The user was already logged in, so we can redirect them immediately
+        router.replace('/dashboard');
+      }
     }
-  }, [member, isInitialized, router]);
+  }, [isInitialized, hasSession, router]);
 
   return <Login />;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { useStytchMemberSession } from '@stytch/nextjs/b2b';
 import Login from '@/src/components/Login';
@@ -8,12 +8,19 @@ import Login from '@/src/components/Login';
 export default function Index() {
   const { session, isInitialized } = useStytchMemberSession();
   const router = useRouter();
-  // If the Stytch SDK detects a User then redirect to profile; for example if a logged in User navigated directly to this URL.
+
+  const alreadyLoggedInRef = useRef<boolean>();
+  const hasSession = !!session;
   useEffect(() => {
-    if (isInitialized && session) {
-      router.replace('/dashboard');
+    if (isInitialized && alreadyLoggedInRef.current === undefined) {
+      alreadyLoggedInRef.current = hasSession;
+
+      if (hasSession) {
+        // The user was already logged in, so we can redirect them immediately
+        router.replace('/dashboard');
+      }
     }
-  }, [session, isInitialized, router]);
+  }, [isInitialized, hasSession, router]);
 
   return <Login />;
 }

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import React from 'react';
+import { useRouter } from 'next/navigation';
 import { StytchB2B } from '@stytch/nextjs/b2b';
+import { StytchEventType } from '@stytch/vanilla-js';
 import { discoveryConfig, discoveryStyles } from '@/lib/stytchConfig';
 import './Login.css';
 
@@ -14,9 +16,21 @@ import './Login.css';
 
 const Login = () => {
 
+  const router = useRouter();
+
   return (
     <div className="centered-login">
-      <StytchB2B config={discoveryConfig} styles={discoveryStyles} />
+      <StytchB2B
+      config={discoveryConfig}
+      styles={discoveryStyles}
+      callbacks={{
+        onEvent: (event) => {
+          if (event.type === StytchEventType.AuthenticateFlowComplete) {
+            router.replace('/dashboard');
+          }
+        },
+      }}
+      />
     </div>
   );
 };


### PR DESCRIPTION
# Description
Our original pattern of using the presence of a logged in member/session to redirect to the home page would redirect before the user had a chance to copy their recovery codes

I think there's probably a question to think through long term about whether or not there is a more intuitive/elegant approach we can do here -- but for now this fixes it

<img width="574" alt="Screenshot 2025-05-14 at 4 27 21 PM" src="https://github.com/user-attachments/assets/2f6d4f92-fc82-4b44-b1ed-33d3b6bdef15" />

Also bumping the SDK versions while I'm here
